### PR TITLE
Select the last line correctly on page down

### DIFF
--- a/dos.c
+++ b/dos.c
@@ -246,7 +246,7 @@ static void page_down(int *index, int *cursor)
 		max_index = (nbentry - (nbentry % LINES));
 
 	if (*index == max_index)
-		*cursor = LINES - 1;
+		*cursor = (nbentry - 1)%LINES;
 	else
 		*cursor = 0;
 


### PR DESCRIPTION
If we are on the last page and do Pagedown again,
we select the last available line

Fixes #14
