### PR TITLE
Fixing build errors on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,11 +28,11 @@ add_library(objects STATIC
 
 add_executable(ngp ${SRCS} ${HEADERS})
 
-# ncurses
-find_package(Curses REQUIRED)
-
 # config
 find_package(PkgConfig REQUIRED)
+
+# ncurses
+pkg_check_modules(CURSES REQUIRED ncurses)
 
 # libconfig
 pkg_check_modules(LIBCONFIG REQUIRED libconfig)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,11 +12,11 @@ add_executable(tests ${SRC_TESTS} ${HEADERS_TESTS})
 
 include_directories(../src)
 
-# ncurses
-find_package(Curses REQUIRED)
-
 # config
 find_package(PkgConfig REQUIRED)
+
+# ncurses
+pkg_check_modules(CURSES REQUIRED ncurses)
 
 # libconfig
 pkg_check_modules(LIBCONFIG REQUIRED libconfig>=1.0)


### PR DESCRIPTION
The current version of cmakes FindCurses seems to drop the libtinfo.so which is required for linking. I switched to PkgConfig for the search for ncurses.