### PR TITLE
Fix local install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,5 +12,5 @@ enable_testing()
 add_test(UNITTESTS, tests/tests)
 
 if(UNIX AND NOT APPLE)
-    install(FILES ngp.1 DESTINATION /usr/share/man/man1)
+    install(FILES ngp.1 DESTINATION usr/share/man/man1)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,4 +49,4 @@ include_directories(${CURSES_INCLUDE_DIRS} ${LIBCONFIG_INCLUDE_DIRS} ${LIBPCRE_I
 target_link_libraries(ngp objects ${CURSES_LIBRARIES} ${LIBPCRE_LIBRARY} ${LIBCONFIG_LIBRARY} pthread)
 
 install(TARGETS ngp DESTINATION bin)
-install(FILES ../ngprc DESTINATION /etc)
+install(FILES ../ngprc DESTINATION etc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,4 +49,4 @@ include_directories(${CURSES_INCLUDE_DIRS} ${LIBCONFIG_INCLUDE_DIRS} ${LIBPCRE_I
 target_link_libraries(ngp objects ${CURSES_LIBRARIES} ${LIBPCRE_LIBRARY} ${LIBCONFIG_LIBRARY} pthread)
 
 install(TARGETS ngp DESTINATION bin)
-install(FILES ../ngprc DESTINATION etc)
+install(FILES ../ngprc DESTINATION etc/ngp)


### PR DESCRIPTION
I just stumbled upon your tool and wanted to test it but because of absolute paths used in CMake `install` commands, a local install wasn't possible. Fixing that by using relative paths only. Note that the paths now default to `/usr/local/…` (or perhaps anything your CMake installation defaults to). I hope that this change is in your favour, otherwise please close it.

**Edit:** I just noted that the search for the config file works with hard coded paths, too. I will investigate that further, if you'd like.