### PR TITLE
Fixing high CPU usage while idling.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -426,7 +426,13 @@ int main(int argc, char *argv[])
             break;
         }
 
-        usleep(10000);
+        // disable no-delay mode after search was finished
+        if (search->status == 0) {
+            nodelay(stdscr, FALSE);
+        } else {
+            usleep(10000);
+        }
+
         lock(search->data_mutex) {
             display_results(display, search, LINES);
             display_status(search);


### PR DESCRIPTION
I noticed that ngp has a relative high CPU usage (5-10%) when idling.  The reason for this is the constant redrawing of the screen, even if there was no user input.
The fix disables the no-delay mode after the search was finished, so that `getch()` will block until there is an input. 