### PR TITLE
Small fixes for config file creation

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -136,7 +136,16 @@ void load_configuration(struct configuration_t *config)
 
     // If file does not exist, create a default ngprc and open it
     char dir[PATH_MAX - strlen(CONFIG_FILE)];
-    snprintf(dir, sizeof(dir), "%s/.config/%s", getenv("HOME"), CONFIG_DIR);
+
+#ifdef __linux__
+    if (!xdg_config_home) {
+#endif /* __linux__ */
+        snprintf(dir, sizeof(dir), "%s/.config/%s", getenv("HOME"), CONFIG_DIR);
+#ifdef __linux__
+    } else {
+        snprintf(dir, sizeof(dir), "%s/%s", xdg_config_home, CONFIG_DIR);
+    }
+#endif /* __linux__ */
 
     if (mkdir(dir, 0777) < 0 && errno != EEXIST) {
        fprintf(stderr, "Failed to create configuration directory %s (%s).\n",

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -137,7 +137,13 @@ void load_configuration(struct configuration_t *config)
     // If file does not exist, create a default ngprc and open it
     char dir[PATH_MAX - strlen(CONFIG_FILE)];
     snprintf(dir, sizeof(dir), "%s/.config/%s", getenv("HOME"), CONFIG_DIR);
-    mkdir(dir, 0777);
+
+    if (mkdir(dir, 0777) < 0 && errno != EEXIST) {
+       fprintf(stderr, "Failed to create configuration directory %s (%s).\n",
+                       dir, strerror(errno));
+       exit(EXIT_FAILURE);
+    }
+
     snprintf(user_ngprc, sizeof(dir), "%s/%s", dir, CONFIG_FILE);
 
     if (access(user_ngprc, R_OK) < 0) {


### PR DESCRIPTION
While installing _ngp_ on WSL with Ubuntu I noticed that the latter is missing `~/.config` causing _ngp_ to crash on first start with a rather confusing error message. It still fails with my changes below, but I think the error message is a little more precise now.

Additionally, _ngp_ now honors `XDG_CONFIG_HOME` while creating the intitial default config file.

Both changes are more a matter of personal taste than anything else, so feel free to merge both, just one or none of them. I found further small details in the config scope (even smaller than these, mostly nitpicking), that I'd gladly provide pull requests for if you'd like.